### PR TITLE
Add support to parallel pregen to only generate angle signatures

### DIFF
--- a/src/bin/pregen.rs
+++ b/src/bin/pregen.rs
@@ -89,6 +89,7 @@ fn main() {
             let mut pos_neg_values: BTreeMap<i64, (String, String)> = BTreeMap::new();
             for (k, v) in all_data {
                 if k == 0 {
+                    pos_neg_values.insert(k, (Direction::SouthEast.to_string(), format!("aqaa{v}")));
                     continue;
                 }
                 pos_neg_values.insert(k, (Direction::SouthEast.to_string(), format!("aqaa{v}")));

--- a/src/bin/pregen.rs
+++ b/src/bin/pregen.rs
@@ -81,14 +81,22 @@ fn main() {
         }
         None => find_patterns(all_targets),
     };
-    if cli.only_tail {
-        fs::write(format!("numbers_{}.json", cli.max), serde_json::to_string_pretty(&all_data).unwrap()).unwrap();
-    } else {
-        let mut pos_neg_values: BTreeMap<i64, (String, String)> = BTreeMap::new();
-        for (k, v) in all_data {
-            pos_neg_values.insert(k, (Direction::SouthEast.to_string(), "aqaa".to_owned() + &v));
-            pos_neg_values.insert(-k, (Direction::NorthEast.to_string(), "dedd".to_owned() + &v));
-        }
-        fs::write(format!("numbers_{}.json", cli.max), serde_json::to_string_pretty(&pos_neg_values).unwrap()).unwrap();
-    }
+
+    fs::write(
+        format!("numers_{}.json", cli.max),
+        if cli.only_tail {
+            serde_json::to_string_pretty(&all_data).unwrap()
+        } else {
+            let mut pos_neg_values: BTreeMap<i64, (String, String)> = BTreeMap::new();
+            for (k, v) in all_data {
+                if k == 0 {
+                    continue;
+                }
+                pos_neg_values.insert(k, (Direction::SouthEast.to_string(), format!("aqaa{v}")));
+                pos_neg_values.insert(-k, (Direction::NorthEast.to_string(), format!("dedd{v}")));
+            }
+            serde_json::to_string_pretty(&pos_neg_values).unwrap()
+        },
+    )
+    .unwrap()
 }

--- a/src/bin/pregen.rs
+++ b/src/bin/pregen.rs
@@ -44,7 +44,6 @@ fn worker(targets: Vec<i64>, tx: Sender<BTreeMap<i64, String>>) {
 }
 
 #[derive(Parser)]
-#[command(author = "Gamma Delta", version = "1", about = "generates hexcasting number literals")]
 struct Cli {
     /// Largest number to generate a literal for.
     max: u64,

--- a/src/bin/pregen.rs
+++ b/src/bin/pregen.rs
@@ -82,7 +82,7 @@ fn main() {
     };
 
     fs::write(
-        format!("numers_{}.json", cli.max),
+        format!("numbers_{}.json", cli.max),
         if cli.only_tail {
             serde_json::to_string_pretty(&all_data).unwrap()
         } else {

--- a/src/bin/pregen.rs
+++ b/src/bin/pregen.rs
@@ -49,7 +49,7 @@ struct Cli {
     /// Largest number to generate a literal for.
     max: u64,
 
-    /// only generate the "tail" of the number literal
+    /// Only generate the "tail" of the number literal (skip aqaa/dedd).
     #[arg(short, long)]
     only_tail: bool,
 


### PR DESCRIPTION
adds the `-o --only-tail` argument which generates only the tail